### PR TITLE
[fix] mne_features numpy dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -585,10 +585,24 @@ if __name__ == '__main__':
             'matplotlib',
             'h5py',
             'sklearn',
-            'mne_features',
+            # 0.2 is the newer source distribution which cannot be
+            # built w/o numpy preinstalled
+            'mne-features==0.1.0',
             'numpy',
         ],
-        tests_require=['pytest', 'pycodestyle', 'isort', 'wheel'],
+        # We need NumPy, and we need it to be this specific version
+        # due to how mne-features wants to be installed.  Once they
+        # fix their package we should be able to remove this
+        # dependency.  The same is true of mne.  We only need it in
+        # here and in setup_requires because of mne-features.
+        tests_require=[
+            'pytest',
+            'pycodestyle',
+            'isort',
+            'wheel',
+            'numpy<1.23.0',
+            'mne',
+        ],
         command_options={
             'build_sphinx': {
                 'project': ('setup.py', name),
@@ -597,7 +611,7 @@ if __name__ == '__main__':
                 'config_dir': ('setup.py', './docs'),
             },
         },
-        setup_requires=['sphinx', 'wheel'],
+        setup_requires=['sphinx', 'wheel', 'numpy<1.23.0', 'mne'],
         extras_require={
             'dev': ['pytest', 'codestyle', 'isort', 'wheel'],
         },


### PR DESCRIPTION
This should "fix" setup issues.

Unfortunately, a proper fix would require from us to adopt and to modify the `mne-features` package because that package has a lot of problems. I've created an issue for them: https://github.com/mne-tools/mne-features/issues/83 but it seems like it's a low-traffic project, so, no idea if it will be fixed and if at all.

One thing we could do: Make our own fork of the project, fix their stuff, and then either vendor it or repackage. But this will require more effort / need a separate discussion. For now, this should allow the pipeline to be green again.