### PR TITLE
[wip] Read BDF files in a way similar to CNT

### DIFF
--- a/eegyolk/config.py
+++ b/eegyolk/config.py
@@ -26,9 +26,14 @@ class Config:
         'metadata': '{}/metadata',
         'preprocessed': '{}/preprocessed',
         'models': '{}/models',
+        'data_2022': '{}/data_2022',
+        'metadata_2022': '{}/metadata_2022',
+        'preprocessed_2022': '{}/preprocessed_2022',
+        'models_2022': '{}/models_2022',
     }
 
     required_directories = 'data', 'metadata'
+    required_directories_2022 = 'data_2022', 'metadata_2022'
 
     def __init__(self, location=None):
         self._raw = None
@@ -114,7 +119,7 @@ class Config:
                 self._loaded[m] = self.default_layout[m].format(root)
 
     def validate(self):
-        for d in self.required_directories:
+        for d in self.required_directories + self.required_directories_2022:
             if not os.path.isdir(self._loaded[d]):
                 logging.error('Directory %s must exist', self._loaded[d])
                 raise ValueError(self.usage())


### PR DESCRIPTION
This is initial work on reading BDF files.

I have questions about how to go about it in general:

* Unlike CNT metadata, the layout of metadata here is such that each observation has two associated BDF files. These files are tied to observations that happened some time apart, which means that records will potentially belong to different age groups. What should we do about this? Split records in two or keep them as they appear in metadata?
* If we choose to keep the structure from the metadata, then the second sampling didn't happen for 22 participants (this is roughly 10% of the entire set), this will have to cause us to throw away the "good" samples from the first session, because it invalidates the whole row. If, however, we restructure the data in such a way that each sample gets its own row, we get to keep the first sampling (i.e. lose roughly 5% of the data).
* I didn't keep some methods eg. `as_mne`, as, currently, it would be difficult to implement (due to there being two files associated with a single record) and, in the original code this method was a "dead end" (i.e. it wasn't necessary for any other code to function). Similarly, I didn't implement `unlabeled()`, `fill_unlabeled()` because those methods were designed to deal with the shortcomings of the data collection specific to CNT files collection. Finally, I didn't implement `count_events()` as it was also a "dead end" method (no other code was interested in calling it).
* It would be probably better if we renamed `read_cnt()` and `read_bdf()` into `read()`, or added an alias, but this would mean possibly touching the loader code (if we want to reuse it on both sets). Is this the plan or do you want to have a separate loader?