### PR TITLE
[fix] Install sklearn-rvm in pre-link script

### DIFF
--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -37,7 +37,9 @@ jobs:
           conda-channels: conda-forge
           python-version: 3.8
       - run: python3 -m venv .venv
-      - run: .venv/bin/python -m pip install wheel
+      - run: .venv/bin/python -m pip install wheel 'numpy<1.23.0' mne
+      - run: .venv/bin/python -m pip uninstall -y setuptools
+      - run: .venv/bin/python -m pip install 'setuptools<60'
       - run: .venv/bin/python setup.py lint
 
 

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -56,10 +56,7 @@ jobs:
       - run: conda config --remove channels defaults
       - name: Generate conda meta.yaml (Python 3.8)
         run: python -u setup.py anaconda_gen_meta
-      - if: ${{ matrix.os == 'macos-latest' }}
-        run: python -u setup.py bdist_conda -o
-      - if: ${{ matrix.os != 'macos-latest' }}
-        run: python -u setup.py bdist_conda
+      - run: python -u setup.py bdist_conda -o
       - name: Upload Anaconda package
         run: >-
           python setup.py anaconda_upload


### PR DESCRIPTION
This should resolve release publishing issue.

The outline of the changes is more or less this: I'll be honest, I don't know which specific change fixed it, but here are the things I discovered:

* Recent changes in `setuptools` allow it to install wheels (it previously only knew how to install eggs). This affects what things are installed and how. Unfortunately, a lot of packages we install have bizarre dependencies on `setuptools`. In particular, `mne`, through `numba` cannot work with the most recent versions. On the other hand, some packages (eg. `scikit-learn` also depend on `setuptools` through `numpy` modules that rely on this package...
* `mne-features` is still problematic because even though they fixed some of the problems, they didn't publish the new version yet.
* `sklearn-rvm` cannot be automatically made consistent with other packages installed by `conda` because there isn't a version of the package created for `conda` and `conda` maintainers refuse to extend package manifests to include dependencies on `pip` packages. It will be installed in `pre-link` script, which, from what I understand, will help with the package building process, but will not help users wanting to install or to depend on our `conda` package as they will have to be instructed to install the package separately.

Potential alternatives to `pre-link` script are:

* Embed `sklearn-rvm` in our package (just copy the sources). If license allows this, this would be the easiest and most convenient way for our users.
* Create `conda` package for `sklearn-rvm`. Same as above, but slightly more work and more responsibility.
* Forget this package exists, partially (i.e. only in `conda` package) or at all. After all, afaikt it is only used in our rewrite of the legacy code we don't really care about anyways.

---

Finally, this doesn't address documentation issues I saw in CI. I'll have to deal with that separately.